### PR TITLE
support user event & refactor state machine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ set_source_files_properties(${pb_srcs} PROPERTIES GENERATED TRUE)
 add_library(pb_lib ${pb_srcs})
 # use "#include <sailgame_pb/core/core.pb.h>"
 target_include_directories(pb_lib PUBLIC ${CMAKE_BINARY_DIR})
+target_include_directories(pb_lib PUBLIC ${pb_dir})
 target_link_libraries(pb_lib PUBLIC 
     ${_REFLECTION} ${_GRPC_GRPCPP} ${_PROTOBUF_LIBPROTOBUF})
 

--- a/include/sailgame/common/core_msg_builder.h
+++ b/include/sailgame/common/core_msg_builder.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <sailgame_pb/core/types.pb.h>
+
+namespace SailGame { namespace Common {
+
+using ::Core::ListenArgs;
+
+class CoreMsgBuilder {
+public:
+    static void SetToken(const std::string &token) { mToken = token; }
+
+    static ListenArgs CreateListenArgs() 
+    {
+        ListenArgs args;
+        args.set_token(mToken);
+        return args;
+    }
+
+private:
+    static std::string mToken;
+};
+
+}}

--- a/include/sailgame/common/event.h
+++ b/include/sailgame/common/event.h
@@ -6,10 +6,19 @@
 #include <sailgame_pb/core/types.pb.h>
 #include <sailgame_pb/uno/uno.pb.h>
 
-namespace SailGame { namespace Common {
+namespace SailGame { 
 
-using Core::ProviderMsg;
+namespace Game {
+
+enum class UserInputEventType;
+
+}
+
+namespace Common {
+
 using Core::BroadcastMsg;
+using Core::ProviderMsg;
+using Game::UserInputEventType;
 
 enum class EventType {
     PROVIDER_MSG,
@@ -39,8 +48,12 @@ struct BroadcastMsgEvent : public Event {
     BroadcastMsg mMsg;
 };
 
-struct UserInputEvent :public Event {
-    UserInputEvent() : Event(EventType::USER_INPUT) {}
-};
+struct UserInputEvent : public Event {
+    UserInputEvent(UserInputEventType type) 
+    : Event(EventType::USER_INPUT), mUserInputType(type) {}
 
+    virtual ~UserInputEvent() {}
+
+    UserInputEventType mUserInputType;
+};
 }}

--- a/include/sailgame/common/event.h
+++ b/include/sailgame/common/event.h
@@ -32,8 +32,15 @@ struct ProviderMsgEvent : public Event {
     ProviderMsg mMsg;
 };
 
-struct BroadcastMsgEvent {};
+struct BroadcastMsgEvent : public Event {
+    BroadcastMsgEvent(const BroadcastMsg &msg)
+        : Event(EventType::BROADCAST_MSG), mMsg(msg) {}
 
-struct UserInputEvent {};
+    BroadcastMsg mMsg;
+};
+
+struct UserInputEvent :public Event {
+    UserInputEvent() : Event(EventType::USER_INPUT) {}
+};
 
 }}

--- a/include/sailgame/common/event.h
+++ b/include/sailgame/common/event.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <memory>
+
+#include <sailgame_pb/core/provider.pb.h>
+#include <sailgame_pb/core/types.pb.h>
+#include <sailgame_pb/uno/uno.pb.h>
+
+namespace SailGame { namespace Common {
+
+using Core::ProviderMsg;
+using Core::BroadcastMsg;
+
+enum class EventType {
+    PROVIDER_MSG,
+    BROADCAST_MSG,
+    USER_INPUT
+};
+
+struct Event {
+    Event(EventType type) : mType(type) {}
+
+    virtual ~Event() {}
+
+    EventType mType;
+};
+
+struct ProviderMsgEvent : public Event {
+    ProviderMsgEvent(const ProviderMsg &msg) 
+        : Event(EventType::PROVIDER_MSG), mMsg(msg) {}
+    
+    ProviderMsg mMsg;
+};
+
+struct BroadcastMsgEvent {};
+
+struct UserInputEvent {};
+
+}}

--- a/include/sailgame/common/event_loop.h
+++ b/include/sailgame/common/event_loop.h
@@ -8,6 +8,7 @@
 #include <sailgame_pb/core/provider.pb.h>
 
 #include "types.h"
+#include "event.h"
 
 namespace SailGame { namespace Common {
 
@@ -15,7 +16,7 @@ using Core::ProviderMsg;
 
 class EventLoopSubscriber {
 public:
-    virtual void OnEventProcessed(const ProviderMsgPtr &) = 0;
+    virtual void OnEventProcessed(const EventPtr &) = 0;
 };
 
 class EventLoop {
@@ -29,7 +30,6 @@ public:
     void StartLoop() {
         while (!mShouldStop) {
             if (!mEventQueue.empty()) {
-                // std::cout << "[EventLoop] Process Event: " << int(mEventQueue.front()->mType) << std::endl;
                 mSubscriber->OnEventProcessed(mEventQueue.front());
                 mEventQueue.pop();
             }
@@ -40,10 +40,9 @@ public:
         mShouldStop = true;
     }
 
-    void AppendEvent(const ProviderMsgPtr &event) {
+    void AppendEvent(const EventPtr &event) {
         // multiple threads may invoke this at the same time
         std::lock_guard<std::mutex> lock(mMutex);
-        // std::cout << "[EventLoop] Append Event: " << int(event->mType) << std::endl;
         mEventQueue.push(event);
     }
 
@@ -54,7 +53,7 @@ public:
     }
 
 private:
-    std::queue<ProviderMsgPtr> mEventQueue;
+    std::queue<EventPtr> mEventQueue;
     std::mutex mMutex;
     EventLoopSubscriber *mSubscriber{nullptr};
     bool mShouldStop{false};

--- a/include/sailgame/common/game_manager.h
+++ b/include/sailgame/common/game_manager.h
@@ -61,9 +61,13 @@ public:
                 break;
             }
             case EventType::BROADCAST_MSG: {
+                auto msg = std::dynamic_pointer_cast<BroadcastMsgEvent>(event)->mMsg;
+                mStateMachine->TransitionForBroadcastMsg(msg);
                 break;
             }
             case EventType::USER_INPUT: {
+                auto operationArgs = mStateMachine->TransitionForUserInput(event);
+                mNetworkInterface->SendOperationInRoomArgs(*operationArgs);
                 break;
             }
             default:

--- a/include/sailgame/common/game_manager.h
+++ b/include/sailgame/common/game_manager.h
@@ -13,14 +13,14 @@ namespace SailGame { namespace Common {
 
 using Core::ProviderMsg;
 
-template<typename StateT>
+template<typename StateT, bool IsProvider>
 class GameManager : 
     public EventLoopSubscriber, 
     public NetworkInterfaceSubscriber {
 public:
     GameManager(const std::shared_ptr<EventLoop> &eventLoop, 
         const std::shared_ptr<StateMachine<StateT>> &stateMachine,
-        const std::shared_ptr<NetworkInterface> &networkInterface)
+        const std::shared_ptr<NetworkInterface<IsProvider>> &networkInterface)
         : mEventLoop(eventLoop), mStateMachine(stateMachine),
         mNetworkInterface(networkInterface)
     {
@@ -42,18 +42,32 @@ public:
 
     void StartWithRegisterArgs(const ProviderMsgPtr &msg) {
         mNetworkInterface->AsyncListen();
-        mNetworkInterface->SendMsg(*msg);
+        mNetworkInterface->AsyncSendMsg(*msg);
         mEventLoop->StartLoop();
     }
 
-    void OnEventHappens(const ProviderMsgPtr &event) override {
+    void OnEventHappens(const EventPtr &event) override {
         mEventLoop->AppendEvent(event);
     }
 
-    void OnEventProcessed(const ProviderMsgPtr &event) override {
-        auto notifyMsgs = mStateMachine->Transition(*event);
-        for (const auto &msg : notifyMsgs) {
-            mNetworkInterface->SendMsg(*msg);
+    void OnEventProcessed(const EventPtr &event) override {
+        switch (event->mType) {
+            case EventType::PROVIDER_MSG: {
+                auto msg = std::dynamic_pointer_cast<ProviderMsgEvent>(event)->mMsg;
+                auto notifyMsgs = mStateMachine->TransitionForProviderMsg(msg);
+                for (const auto &msg : notifyMsgs) {
+                    mNetworkInterface->AsyncSendMsg(*msg);
+                }
+                break;
+            }
+            case EventType::BROADCAST_MSG: {
+                break;
+            }
+            case EventType::USER_INPUT: {
+                break;
+            }
+            default:
+                throw std::runtime_error("Unsupported event type.");
         }
     }
 
@@ -61,6 +75,6 @@ public:
 private:
     std::shared_ptr<EventLoop> mEventLoop;
     std::shared_ptr<StateMachine<StateT>> mStateMachine;
-    std::shared_ptr<NetworkInterface> mNetworkInterface;
+    std::shared_ptr<NetworkInterface<IsProvider>> mNetworkInterface;
 };
 }}

--- a/include/sailgame/common/network_interface.h
+++ b/include/sailgame/common/network_interface.h
@@ -17,6 +17,8 @@
 #include "types.h"
 #include "event.h"
 #include "util.h"
+#include "core_msg_builder.h"
+#include "provider_msg_builder.h"
 
 namespace SailGame { namespace Common {
 
@@ -63,7 +65,7 @@ public:
             mStream = mStub->Provider(&mContext);
         }
         else {
-            // mStream = mStub->Listen(&mContext, /*listenArgs*/);
+            mStream = mStub->Listen(&mContext, CoreMsgBuilder::CreateListenArgs());
         }
     }
 

--- a/include/sailgame/common/provider_msg_builder.h
+++ b/include/sailgame/common/provider_msg_builder.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <sailgame_pb/core/provider.pb.h>
+#include <sailgame_pb/core/error.pb.h>
+#include <sailgame_pb/core/types.pb.h>
+
+#include "types.h"
+#include "util.h"
+
+namespace SailGame { namespace Common {
+
+using Core::ErrorNumber;
+using Core::ProviderMsg;
+using Common::Util;
+
+class ProviderMsgBuilder {
+public:
+    static ProviderMsg CreateRegisterArgs(int seqId, const std::string &id,
+        const std::string &gameName, int maxUsers, int minUsers)
+    {
+        ProviderMsg msg;
+        msg.set_sequenceid(seqId);
+
+        auto registerArgs = msg.mutable_registerargs();
+        registerArgs->set_id(id);
+        registerArgs->set_gamename(gameName);
+
+        auto gameSettings = registerArgs->mutable_gamesetting();
+        gameSettings->set_maxusers(maxUsers);
+        gameSettings->set_minusers(minUsers);
+
+        return msg;
+    }
+
+    template<typename NotifyMsgT>
+    static ProviderMsg CreateNotifyMsgArgs(int seqId, ErrorNumber err, 
+        int roomId, int userId, const NotifyMsgT &custom)
+    {
+        ProviderMsg msg;
+        msg.set_sequenceid(seqId);
+
+        auto args = msg.mutable_notifymsgargs();
+        args->set_err(err);
+        args->set_roomid(roomId);
+        args->set_userid(userId);
+        args->mutable_custom()->PackFrom(custom);
+
+        return msg;
+    }
+        
+    static ProviderMsg CreateRegisterRet(int seqId, ErrorNumber err)
+    {
+        ProviderMsg msg;
+        msg.set_sequenceid(seqId);
+
+        auto ret = msg.mutable_registerret();
+        ret->set_err(err);
+
+        return msg;
+    }
+
+    template<typename StartGameSettingsT>
+    static ProviderMsg CreateStartGameArgs(int seqId, int roomId, 
+        const std::vector<unsigned int> userIds, const StartGameSettingsT &custom)
+    {
+        ProviderMsg msg;
+        msg.set_sequenceid(seqId);
+
+        auto args = msg.mutable_startgameargs();
+        args->set_roomid(roomId);
+        args->mutable_userid()->CopyFrom(
+            Util::ConvertVectorToGrpcRepeatedField<unsigned int>(userIds));
+        args->mutable_custom()->PackFrom(custom);
+
+        return msg;
+    }
+    
+    template<typename UserOperationT>
+    static ProviderMsg CreateUserOperationArgs(int seqId, int roomId,
+        int userId, const UserOperationT &custom)
+    {
+        ProviderMsg msg;
+        msg.set_sequenceid(seqId);
+
+        auto args = msg.mutable_useroperationargs();
+        args->set_roomid(roomId);
+        args->set_userid(userId);
+        args->mutable_custom()->PackFrom(custom);
+
+        return msg;
+    }
+
+};
+}}

--- a/include/sailgame/common/state_machine.h
+++ b/include/sailgame/common/state_machine.h
@@ -16,7 +16,7 @@ public:
     }
 
     template<typename MsgT>
-    ProviderMsgPtrs Transition(const MsgT &event) {
+    ProviderMsgPtrs TransitionForProviderMsg(const MsgT &event) {
         throw std::runtime_error("Unsupported msg type");
     }
 

--- a/include/sailgame/common/state_machine.h
+++ b/include/sailgame/common/state_machine.h
@@ -20,6 +20,16 @@ public:
         throw std::runtime_error("Unsupported msg type");
     }
 
+    template<typename MsgT>
+    void TransitionForBroadcastMsg(const MsgT &event) {
+        throw std::runtime_error("Unsupported msg type");
+    }
+
+    template<typename EventT>
+    OperationInRoomArgsPtr TransitionForUserInput(const EventT &event) {
+        throw std::runtime_error("Unsupported event type");
+    }
+
     const StateT &GetState() const { return mState; } 
 
 private:

--- a/include/sailgame/common/types.h
+++ b/include/sailgame/common/types.h
@@ -12,10 +12,11 @@ struct OperationInRoomArgs;
 namespace SailGame { namespace Common {
 
 struct Event;
-using ProviderMsgPtr = std::shared_ptr<Core::ProviderMsg>;
-using ProviderMsgPtrs = std::vector<ProviderMsgPtr>;
-using UserOperationPtr = std::shared_ptr<Core::UserOperation>;
-using UserOperationPtrs = std::vector<UserOperationPtr>;
+using ProviderMsgs = std::vector<Core::ProviderMsg>;
+// using ProviderMsgPtr = std::shared_ptr<Core::ProviderMsg>;
+// using ProviderMsgPtrs = std::vector<ProviderMsgPtr>;
+// using UserOperationPtr = std::shared_ptr<Core::UserOperation>;
+// using UserOperationPtrs = std::vector<UserOperationPtr>;
 using EventPtr = std::shared_ptr<Event>;
-using OperationInRoomArgsPtr = std::shared_ptr<Core::OperationInRoomArgs>;
+// using OperationInRoomArgsPtr = std::shared_ptr<Core::OperationInRoomArgs>;
 }}

--- a/include/sailgame/common/types.h
+++ b/include/sailgame/common/types.h
@@ -5,10 +5,16 @@
 
 namespace Core {
 struct ProviderMsg;
+struct UserOperation;
 }
 
 namespace SailGame { namespace Common {
 
+struct Event;
 using ProviderMsgPtr = std::shared_ptr<Core::ProviderMsg>;
 using ProviderMsgPtrs = std::vector<ProviderMsgPtr>;
+using UserOperationPtr = std::shared_ptr<Core::UserOperation>;
+using UserOperationPtrs = std::vector<UserOperationPtr>;
+using EventPtr = std::shared_ptr<Event>;
+
 }}

--- a/include/sailgame/common/types.h
+++ b/include/sailgame/common/types.h
@@ -6,6 +6,7 @@
 namespace Core {
 struct ProviderMsg;
 struct UserOperation;
+struct OperationInRoomArgs;
 }
 
 namespace SailGame { namespace Common {
@@ -16,5 +17,5 @@ using ProviderMsgPtrs = std::vector<ProviderMsgPtr>;
 using UserOperationPtr = std::shared_ptr<Core::UserOperation>;
 using UserOperationPtrs = std::vector<UserOperationPtr>;
 using EventPtr = std::shared_ptr<Event>;
-
+using OperationInRoomArgsPtr = std::shared_ptr<Core::OperationInRoomArgs>;
 }}

--- a/include/sailgame/common/util.h
+++ b/include/sailgame/common/util.h
@@ -16,6 +16,7 @@ namespace SailGame { namespace Common {
 
 using google::protobuf::Any;
 using google::protobuf::RepeatedField;
+using google::protobuf::RepeatedPtrField;
 using grpc::ClientReaderWriterInterface;
 using grpc::ClientReaderInterface;
 using Core::ProviderMsg;
@@ -26,6 +27,16 @@ public:
     template<typename T>
     static std::vector<T> ConvertGrpcRepeatedFieldToVector(const RepeatedField<T> &field) {
         /// XXX: it seems also ok to move instead of copy
+        static_assert(std::is_copy_constructible_v<T>);
+        std::vector<T> v;
+        for (const auto &element : field) {
+            v.push_back(element);
+        }
+        return v;
+    }
+
+    template<typename T>
+    static std::vector<T> ConvertGrpcRepeatedPtrFieldToVector(const RepeatedPtrField<T> &field) {
         static_assert(std::is_copy_constructible_v<T>);
         std::vector<T> v;
         for (const auto &element : field) {

--- a/include/sailgame/common/util.h
+++ b/include/sailgame/common/util.h
@@ -5,11 +5,21 @@
 #include <type_traits>
 #include <google/protobuf/any.pb.h>
 #include <google/protobuf/repeated_field.h>
+#include <grpcpp/impl/codegen/sync_stream.h>
+
+#include <sailgame_pb/core/types.pb.h>
+#include <sailgame_pb/core/provider.pb.h>
+
+#include "event.h"
 
 namespace SailGame { namespace Common {
 
 using google::protobuf::Any;
 using google::protobuf::RepeatedField;
+using grpc::ClientReaderWriterInterface;
+using grpc::ClientReaderInterface;
+using Core::ProviderMsg;
+using Core::BroadcastMsg;
 
 class Util {
 public:
@@ -42,5 +52,31 @@ public:
         return ret;
     }
 };
+
+template<bool IsProvider>
+struct get_network_type;
+
+template<>
+struct get_network_type<true> {
+    using msg_type = ProviderMsg;
+    using stream_type = ClientReaderWriterInterface<ProviderMsg, ProviderMsg>;
+    using event_type = ProviderMsgEvent;
+};
+
+template<>
+struct get_network_type<false> {
+    using msg_type = BroadcastMsg;
+    using stream_type = ClientReaderInterface<BroadcastMsg>;
+    using event_type = BroadcastMsgEvent;
+};
+
+template<bool IsProvider>
+using get_msg_t = typename get_network_type<IsProvider>::msg_type;
+
+template<bool IsProvider>
+using get_stream_t = typename get_network_type<IsProvider>::stream_type;
+
+template <bool IsProvider>
+using get_event_t = typename get_network_type<IsProvider>::event_type;
 
 }}

--- a/include/sailgame/uno/card.h
+++ b/include/sailgame/uno/card.h
@@ -7,7 +7,7 @@
 
 #include <sailgame_pb/uno/uno.pb.h>
 
-namespace SailGame { namespace Game {
+namespace SailGame { namespace Uno {
 
 using ::Uno::CardColor;
 using ::Uno::CardText;

--- a/include/sailgame/uno/msg_builder.h
+++ b/include/sailgame/uno/msg_builder.h
@@ -8,7 +8,7 @@
 #include "../common/types.h"
 #include "../common/util.h"
 
-namespace SailGame { namespace Game {
+namespace SailGame { namespace Uno {
 
 using ::Uno::GameStart;
 using ::Uno::NotifyMsg;
@@ -18,30 +18,15 @@ using ::Uno::Draw;
 using ::Uno::Skip;
 using ::Uno::Play;
 using ::Uno::CardColor;
-using Core::ErrorNumber;
-using Core::NotifyMsgArgs;
-using Core::ProviderMsg;
-using Common::ProviderMsgPtr;
+using ::Core::ErrorNumber;
+using ::Core::NotifyMsgArgs;
+using ::Core::ProviderMsg;
 using Common::Util;
 
 class MsgBuilder {
 public:
-    static ProviderMsgPtr CreateRegisterArgs(int seqId, const std::string &id,
-        const std::string &gameName, int maxUsers, int minUsers);
-
-    static ProviderMsgPtr CreateRegisterRet(int seqId, ErrorNumber err);
-
-    static ProviderMsgPtr CreateStartGameArgs(int seqId, int roomId, 
-        const std::vector<unsigned int> userIds, const StartGameSettings &custom);
-    
     static StartGameSettings CreateStartGameSettings(bool isDraw2Consumed,
         bool canSkipRespond, bool hasWildSwapHandsCard, bool canDoubtDraw4, int roundTime);
-
-    static ProviderMsgPtr CreateNotifyMsgArgs(int seqId, ErrorNumber err, 
-        int roomId, int userId, const NotifyMsg &custom);
-
-    static ProviderMsgPtr CreateUserOperationArgs(int seqId, int roomId,
-        int userId, const UserOperation &custom);
 
     static NotifyMsg CreateGameStart(const InitHandcardsT &initHandcards, 
         Card flippedCard, int firstPlayer);

--- a/src/uno/card.cc
+++ b/src/uno/card.cc
@@ -1,6 +1,6 @@
 #include <sailgame/uno/card.h>
 
-namespace SailGame { namespace Game {
+namespace SailGame { namespace Uno {
 
 const std::set<CardColor> CardSet::NonWildColors = 
     { CardColor::RED, CardColor::YELLOW, CardColor::GREEN, CardColor::BLUE };

--- a/src/uno/msg_builder.cc
+++ b/src/uno/msg_builder.cc
@@ -1,48 +1,6 @@
 #include <sailgame/uno/msg_builder.h>
 
-namespace SailGame { namespace Game {
-
-ProviderMsgPtr MsgBuilder::CreateRegisterArgs(int seqId, const std::string &id,
-    const std::string &gameName, int maxUsers, int minUsers)
-{
-    auto msg = std::make_shared<ProviderMsg>();
-    msg->set_sequenceid(seqId);
-
-    auto registerArgs = msg->mutable_registerargs();
-    registerArgs->set_id(id);
-    registerArgs->set_gamename(gameName);
-
-    auto gameSettings = registerArgs->mutable_gamesetting();
-    gameSettings->set_maxusers(maxUsers);
-    gameSettings->set_minusers(minUsers);
-
-    return msg;
-}
-
-ProviderMsgPtr MsgBuilder::CreateRegisterRet(int seqId, ErrorNumber err)
-{
-    auto msg = std::make_shared<ProviderMsg>();
-    msg->set_sequenceid(seqId);
-
-    auto ret = msg->mutable_registerret();
-    ret->set_err(err);
-
-    return msg;
-}
-
-ProviderMsgPtr MsgBuilder::CreateStartGameArgs(int seqId, int roomId, 
-    const std::vector<unsigned int> userIds, const StartGameSettings &custom)
-{
-    auto msg = std::make_shared<ProviderMsg>();
-    msg->set_sequenceid(seqId);
-
-    auto args = msg->mutable_startgameargs();
-    args->set_roomid(roomId);
-    args->mutable_userid()->CopyFrom(Util::ConvertVectorToGrpcRepeatedField<unsigned int>(userIds));
-    args->mutable_custom()->PackFrom(custom);
-
-    return msg;
-}
+namespace SailGame { namespace Uno {
 
 StartGameSettings MsgBuilder::CreateStartGameSettings(bool isDraw2Consumed,
     bool canSkipRespond, bool hasWildSwapHandsCard, bool canDoubtDraw4, int roundTime)
@@ -54,35 +12,6 @@ StartGameSettings MsgBuilder::CreateStartGameSettings(bool isDraw2Consumed,
     settings.set_candoubtdraw4(canDoubtDraw4);
     settings.set_roundtime(roundTime);
     return settings;
-}
-
-ProviderMsgPtr MsgBuilder::CreateNotifyMsgArgs(int seqId, ErrorNumber err, 
-    int roomId, int userId, const NotifyMsg &custom) 
-{
-    auto msg = std::make_shared<ProviderMsg>();
-    msg->set_sequenceid(seqId);
-
-    auto args = msg->mutable_notifymsgargs();
-    args->set_err(err);
-    args->set_roomid(roomId);
-    args->set_userid(userId);
-    args->mutable_custom()->PackFrom(custom);
-
-    return msg;
-}
-
-ProviderMsgPtr MsgBuilder::CreateUserOperationArgs(int seqId, int roomId,
-    int userId, const UserOperation &custom)
-{
-    auto msg = std::make_shared<ProviderMsg>();
-    msg->set_sequenceid(seqId);
-
-    auto args = msg->mutable_useroperationargs();
-    args->set_roomid(roomId);
-    args->set_userid(userId);
-    args->mutable_custom()->PackFrom(custom);
-
-    return msg;
 }
 
 NotifyMsg MsgBuilder::CreateGameStart(const InitHandcardsT &initHandcards, 


### PR DESCRIPTION
+ add an abstract layer of `Event`, it can now represent three kinds of event: provider msg on provider side, broadcast msg and user input on client side.
+ enhance `NetworkInterface`, add support for client side
+ refactor `StateMachine`, use OOP instead of template